### PR TITLE
Remove field labels from product types

### DIFF
--- a/Metaprogrammable/Metatype.swift
+++ b/Metaprogrammable/Metatype.swift
@@ -16,8 +16,8 @@ public enum Metatype: Metaprogrammable {
 
 	public static var metatype: Metatype {
 		return .Structural([
-			"Structural": [ (nil, Sum.metatype) ],
-			"Opaque": [ (nil, .Opaque(Any.Type.self)) ],
+			"Structural": [ Sum.metatype ],
+			"Opaque": [ .Opaque(Any.Type.self) ],
 			"Recurrence": [],
 		])
 	}

--- a/Metaprogrammable/Product.swift
+++ b/Metaprogrammable/Product.swift
@@ -1,16 +1,16 @@
 //  Copyright © 2015 Rob Rix. All rights reserved.
 
 public enum Product: ArrayLiteralConvertible, Metaprogrammable {
-	indirect case Field((String?, Metatype), Product)
+	indirect case Field(Metatype, Product)
 	case End
 
-	public init(arrayLiteral: (String?, Metatype)...) {
+	public init(arrayLiteral: Metatype...) {
 		self = arrayLiteral.fold(.End, combine: Product.Field)
 	}
 
 	public static var metatype: Metatype {
 		return .Structural([
-			"Field": [ (nil, .Opaque(String.self)), (nil, .Recurrence) ],
+			"Field": [ .Opaque(String.self), .Recurrence ],
 			"End": [],
 		])
 	}

--- a/Metaprogrammable/Product.swift
+++ b/Metaprogrammable/Product.swift
@@ -10,7 +10,7 @@ public enum Product: ArrayLiteralConvertible, Metaprogrammable {
 
 	public static var metatype: Metatype {
 		return .Structural([
-			"Field": [ .Opaque(String.self), .Recurrence ],
+			"Field": [ Metatype.metatype, .Recurrence ],
 			"End": [],
 		])
 	}

--- a/Metaprogrammable/Sum.swift
+++ b/Metaprogrammable/Sum.swift
@@ -10,7 +10,7 @@ public enum Sum: DictionaryLiteralConvertible, Metaprogrammable {
 
 	public static var metatype: Metatype {
 		return .Structural([
-			"Branch": [ (nil, .Opaque(String.self)), (nil, Product.metatype), (nil, .Recurrence) ],
+			"Branch": [ .Opaque(String.self), Product.metatype, .Recurrence ],
 			"End": [],
 		])
 	}


### PR DESCRIPTION
Field labels are unnecessary for our current purposes, so they’ve been removed.

I’ve also corrected Product’s `metatype`.

Note however that computing the metatype of `Sum`, `Product`, or `Metatype` will now diverge due to strict evaluation.
