### PR TITLE
Non-strict type graphs

### DIFF
--- a/Metaprogrammable/Metatype.swift
+++ b/Metaprogrammable/Metatype.swift
@@ -18,13 +18,17 @@ public enum Metatype: CustomStringConvertible, Metaprogrammable {
 		}
 	}
 
+	public init<T>(_ type: T.Type, _ structure: Sum) {
+		self = Structural(type, structure)
+	}
+
 
 	public var description: String {
 		return String(type)
 	}
 
 	public static var metatype: Metatype {
-		return Structural(self, [
+		return Metatype(self, [
 			"Structural": [ Sum.metatype ],
 			"Opaque": [ .Opaque(Any.Type.self) ],
 		])

--- a/Metaprogrammable/Metatype.swift
+++ b/Metaprogrammable/Metatype.swift
@@ -3,7 +3,7 @@
 /// A description of the structure of a type.
 public enum Metatype: CustomStringConvertible, Metaprogrammable {
 	/// A structural, or algebraic, type.
-	case Structural(Any.Type, Sum)
+	case Structural(Any.Type, () -> Sum)
 
 	/// An opaque reference to a type.
 	case Opaque(Any.Type)
@@ -18,7 +18,7 @@ public enum Metatype: CustomStringConvertible, Metaprogrammable {
 		}
 	}
 
-	public init<T>(_ type: T.Type, _ structure: Sum) {
+	public init<T>(_ type: T.Type, @autoclosure(escaping) _ structure: () -> Sum) {
 		self = Structural(type, structure)
 	}
 

--- a/Metaprogrammable/Metatype.swift
+++ b/Metaprogrammable/Metatype.swift
@@ -9,6 +9,16 @@ public enum Metatype: CustomStringConvertible, Metaprogrammable {
 	case Opaque(Any.Type)
 
 
+	public var type: Any.Type {
+		switch self {
+		case let .Structural(t, _):
+			return t
+		case let .Opaque(t):
+			return t
+		}
+	}
+
+
 	public var description: String {
 		switch self {
 		case let .Structural(t, _):

--- a/Metaprogrammable/Metatype.swift
+++ b/Metaprogrammable/Metatype.swift
@@ -20,12 +20,7 @@ public enum Metatype: CustomStringConvertible, Metaprogrammable {
 
 
 	public var description: String {
-		switch self {
-		case let .Structural(t, _):
-			return String(t)
-		case let .Opaque(t):
-			return String(t)
-		}
+		return String(type)
 	}
 
 	public static var metatype: Metatype {

--- a/Metaprogrammable/Metatype.swift
+++ b/Metaprogrammable/Metatype.swift
@@ -1,7 +1,7 @@
 //  Copyright © 2015 Rob Rix. All rights reserved.
 
 /// A description of the structure of a type.
-public enum Metatype: Metaprogrammable {
+public enum Metatype: CustomStringConvertible, Metaprogrammable {
 	/// A structural, or algebraic, type.
 	case Structural(Any.Type, Sum)
 
@@ -9,6 +9,14 @@ public enum Metatype: Metaprogrammable {
 	case Opaque(Any.Type)
 
 
+	public var description: String {
+		switch self {
+		case let .Structural(t, _):
+			return String(t)
+		case let .Opaque(t):
+			return String(t)
+		}
+	}
 
 	public static var metatype: Metatype {
 		return Structural(self, [

--- a/Metaprogrammable/Metatype.swift
+++ b/Metaprogrammable/Metatype.swift
@@ -27,7 +27,6 @@ public enum Metatype: CustomStringConvertible, Metaprogrammable {
 		return Structural(self, [
 			"Structural": [ Sum.metatype ],
 			"Opaque": [ .Opaque(Any.Type.self) ],
-			"Recurrence": [],
 		])
 	}
 }

--- a/Metaprogrammable/Metatype.swift
+++ b/Metaprogrammable/Metatype.swift
@@ -8,10 +8,6 @@ public enum Metatype: Metaprogrammable {
 	/// An opaque reference to a type.
 	case Opaque(Any.Type)
 
-	/// A recursive reference to the type.
-	///
-	/// This can only appear within `Sum`s and `Product`s.
-	case Recurrence
 
 
 	public static var metatype: Metatype {

--- a/Metaprogrammable/Metatype.swift
+++ b/Metaprogrammable/Metatype.swift
@@ -3,7 +3,7 @@
 /// A description of the structure of a type.
 public enum Metatype: Metaprogrammable {
 	/// A structural, or algebraic, type.
-	case Structural(Sum)
+	case Structural(Any.Type, Sum)
 
 	/// An opaque reference to a type.
 	case Opaque(Any.Type)
@@ -11,7 +11,7 @@ public enum Metatype: Metaprogrammable {
 
 
 	public static var metatype: Metatype {
-		return .Structural([
+		return Structural(self, [
 			"Structural": [ Sum.metatype ],
 			"Opaque": [ .Opaque(Any.Type.self) ],
 			"Recurrence": [],

--- a/Metaprogrammable/Product.swift
+++ b/Metaprogrammable/Product.swift
@@ -10,7 +10,7 @@ public enum Product: ArrayLiteralConvertible, Metaprogrammable {
 
 	public static var metatype: Metatype {
 		return .Structural([
-			"Field": [ Metatype.metatype, .Recurrence ],
+			"Field": [ Metatype.metatype, /*.Recurrence*/ ],
 			"End": [],
 		])
 	}

--- a/Metaprogrammable/Product.swift
+++ b/Metaprogrammable/Product.swift
@@ -9,8 +9,8 @@ public enum Product: ArrayLiteralConvertible, Metaprogrammable {
 	}
 
 	public static var metatype: Metatype {
-		return .Structural(self, [
-			"Field": [ Metatype.metatype, /*.Recurrence*/ ],
+		return Metatype(self, [
+			"Field": [ Metatype.metatype, self.metatype ],
 			"End": [],
 		])
 	}

--- a/Metaprogrammable/Product.swift
+++ b/Metaprogrammable/Product.swift
@@ -9,7 +9,7 @@ public enum Product: ArrayLiteralConvertible, Metaprogrammable {
 	}
 
 	public static var metatype: Metatype {
-		return .Structural([
+		return .Structural(self, [
 			"Field": [ Metatype.metatype, /*.Recurrence*/ ],
 			"End": [],
 		])

--- a/Metaprogrammable/Sum.swift
+++ b/Metaprogrammable/Sum.swift
@@ -9,7 +9,7 @@ public enum Sum: DictionaryLiteralConvertible, Metaprogrammable {
 	}
 
 	public static var metatype: Metatype {
-		return .Structural([
+		return .Structural(self, [
 			"Branch": [ .Opaque(String.self), Product.metatype, /*.Recurrence*/ ],
 			"End": [],
 		])

--- a/Metaprogrammable/Sum.swift
+++ b/Metaprogrammable/Sum.swift
@@ -9,8 +9,8 @@ public enum Sum: DictionaryLiteralConvertible, Metaprogrammable {
 	}
 
 	public static var metatype: Metatype {
-		return .Structural(self, [
-			"Branch": [ .Opaque(String.self), Product.metatype, /*.Recurrence*/ ],
+		return Metatype(self, [
+			"Branch": [ .Opaque(String.self), Product.metatype, self.metatype ],
 			"End": [],
 		])
 	}

--- a/Metaprogrammable/Sum.swift
+++ b/Metaprogrammable/Sum.swift
@@ -10,7 +10,7 @@ public enum Sum: DictionaryLiteralConvertible, Metaprogrammable {
 
 	public static var metatype: Metatype {
 		return .Structural([
-			"Branch": [ .Opaque(String.self), Product.metatype, .Recurrence ],
+			"Branch": [ .Opaque(String.self), Product.metatype, /*.Recurrence*/ ],
 			"End": [],
 		])
 	}


### PR DESCRIPTION
- Uses `@autoclosure` to avoid divergence with recursive type graphs.
- Removes `Metatype.Recurrence`.
